### PR TITLE
Outputting the Exception to the standard error

### DIFF
--- a/src/Tools.Net.Mongo/Program.cs
+++ b/src/Tools.Net.Mongo/Program.cs
@@ -47,9 +47,11 @@ namespace Tools.Net.Mongo
                 }
                 while (argList.Count != 0);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                Console.WriteLine("Error: An unexpected error occurred.");
+                Console.Error.WriteLine("Error: An unexpected error occurred.");
+                Console.Error.WriteLine(ex);
+                Environment.ExitCode = -1;
             }
 
 #if DEBUG


### PR DESCRIPTION
Currently, when running the tool I'm getting an exception but it's being thrown away once captured, this is a small PR to output the exception to the standard error output and also change the exit code to `-1`.